### PR TITLE
FilterMapBench option with bitwise for  even comparison

### DIFF
--- a/filter_map_bench.exs
+++ b/filter_map_bench.exs
@@ -24,6 +24,12 @@ defmodule FilterMapBench do
     end
   end
 
+  bench "For comprehension removing odd values with bitwise without function capture" do
+    for val <- @values, even_bitwise?(val) do
+      square(val)
+    end
+  end
+
   bench ":lists.filtermap with function capture" do
     # Simulate wrapping this all in a utility function
     mapper = fn val -> val * val end
@@ -53,6 +59,7 @@ defmodule FilterMapBench do
     )
   end
 
+  defp even_bitwise?(val), do: Bitwise.band(val, 1) == 0
   defp even?(val), do: rem(val, 2) == 0
   defp square(val), do: val * val
 end


### PR DESCRIPTION
```
## FilterMapBench
benchmark name                                                               iterations   average time
For comprehension removing odd values with bitwise without function capture       20000   79.95 µs/op
For comprehension removing odd values without function capture                    20000   83.91 µs/op
For comprehension removing odd values with function capture                       20000   84.41 µs/op
Map + filter                                                                      10000   134.66 µs/op
:lists.filtermap with function capture                                            10000   203.77 µs/op
:lists.filtermap without function capture                                         10000   208.27 µs/op
```